### PR TITLE
Fix python comments and other issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupysql-plugin",
-    "version": "5.4.5",
+    "version": "5.4.6",
     "description": "Jupyterlab extension for JupySQL",
     "private": true,
     "keywords": [

--- a/src/completer/customconnector.ts
+++ b/src/completer/customconnector.ts
@@ -167,6 +167,7 @@ namespace Private {
       );
     });
 
+    // The start of the completed token, the end, and the completed items
     return {
       start: token.offset,
       end: token.offset + token.value.length,

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -1,6 +1,7 @@
 import {Extension} from "@codemirror/state"
 import {sql, SQLDialect,PostgreSQL} from '@codemirror/lang-sql'
-import {parser as pythonParser} from '@lezer/python'
+import { pythonLanguage } from '@codemirror/lang-python'
+// import {parser as pythonParser} from '@lezer/python'
 import {parseMixed} from "@lezer/common"
 import {LRLanguage} from "@codemirror/language"
 import {keywords as snowflakeKeywordsSchema, functions as snowflakeFunctionsSchema} from '../snowflake_schema.json';
@@ -41,10 +42,8 @@ const sqlLang = sql(config);
 
 function skiPython() {
 
-    const mixedPythonLanguage = pythonParser.configure({
+    const mixedPythonLanguage = pythonLanguage.parser.configure({
         wrap: parseMixed((node, input) => {
-
-
             const nodeIsAcceptedStringType =
                 node.name === 'String' || node.name === 'FormatString';
 
@@ -135,7 +134,17 @@ const skiParser = skiPython();
 
 
 const skiPythonLRLanguage = LRLanguage.define({
-    parser: skiParser
+    parser: skiParser,
+    // Keep settings from the python language (copied from their source)
+    languageData: {
+        closeBrackets: {
+            brackets: ["(", "[", "{", "'", '"', "'''", '"""'],
+            stringPrefixes: ["f", "fr", "rf", "r", "u", "b", "br", "rb",
+                "F", "FR", "RF", "R", "U", "B", "BR", "RB"]
+        },
+        commentTokens: { line: "-" },
+        indentOnInput: /^\s*([\}\]\)]|else:|elif |except |finally:)$/
+    }
 })
 
 

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -142,7 +142,7 @@ const skiPythonLRLanguage = LRLanguage.define({
             stringPrefixes: ["f", "fr", "rf", "r", "u", "b", "br", "rb",
                 "F", "FR", "RF", "R", "U", "B", "BR", "RB"]
         },
-        commentTokens: { line: "-" },
+        commentTokens: { line: "#" },
         indentOnInput: /^\s*([\}\]\)]|else:|elif |except |finally:)$/
     }
 })

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -78,6 +78,7 @@ export class JupyterlabNotebookCodeFormatter {
                     try {
                         const query = format(sqlCommand[1], { language: 'sql', keywordCase: 'upper' })
                         console.log(query)
+                        // Replace the original code line with a formatted query
                         cell.model.sharedModel.source = text.replace(sqlCommand[1], query)
                     } catch (error) {
                     }


### PR DESCRIPTION
Use the python parser from the original python language defined in code mirror, and also copy the settings of the language from their source, to keep the original python behaviour of adding comments and some indentation issues in python that it created